### PR TITLE
Add mocks for RPi.GPIO event functions and constants

### DIFF
--- a/fake_rpi/RPi/GPIO.py
+++ b/fake_rpi/RPi/GPIO.py
@@ -65,7 +65,7 @@ def setmode(a): pass
 def getmode(): return BCM
 
 @printf
-def setup(channel, state, initial=LOW): pass
+def setup(channel, state, initial=LOW, pull_up_down=None): pass
 
 @printf
 def input(a): return randint(0, 1)

--- a/fake_rpi/RPi/GPIO.py
+++ b/fake_rpi/RPi/GPIO.py
@@ -21,19 +21,36 @@ class PWM(Base):
 	def ChangeFrequency(self, frequency):
 		pass
 
-
+# Values
 LOW = 0
 HIGH = 1
-IN = 1
-OUT = 0
+
+# Modes
 BCM = 11
 BOARD = 10
-PUD_UP = 22
+
+# Pull
+PUD_OFF = 20
 PUD_DOWN = 21
-I2C = 42
-SPI = 41
+PUD_UP = 22
+
+# Edges
 RISING = 31
+FALLING = 32
+BOTH = 33
+
+# Functions
+OUT = 0
+IN = 1
+SERIAL = 40
+SPI = 41
+I2C = 42
+HARD_PWM = 43
 UNKNOWN = -1
+
+# Versioning
+RPI_REVISION = 2
+VERSION = '0.5.6'
 
 def __init__(self):
 	Base.__init__(self, self.__class__)
@@ -58,3 +75,21 @@ def cleanup(a=None): pass
 
 @printf
 def output(channel, state): pass
+
+@printf
+def wait_for_edge(channel, edge): pass
+
+@printf
+def add_event_detect(channel, edge, callback=None, bouncetime=None): pass
+
+@printf
+def add_event_callback(channel, callback=None): pass
+
+@printf
+def remove_event_detect(channel): pass
+
+@printf
+def event_detected(channel): return False
+
+@printf
+def gpio_function(channel): return OUT


### PR DESCRIPTION
Add missing mocks for RPi.GPIO, like `add_event_detect(channel, edge, callback=None, bouncetime=None)`, `wait_for_edge(channel, edge)` and constants.