### PR TITLE
picamera: add enter and exit so 'with picamera' contextmanager works

### DIFF
--- a/fake_rpi/picamera.py
+++ b/fake_rpi/picamera.py
@@ -30,6 +30,12 @@ class PiCamera(Base):
 		Base.__init__(self, self.__class__)
 		pass
 
+	def __enter__(self):
+		return self
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		pass
+
 	def close(self):
 		# this does nothing
 		pass


### PR DESCRIPTION
This allows basic use of

```python

with picamera ...
```