### PR TITLE
Fixed readme to explain usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,8 @@ code must be executed before your application:
 import sys
 import fake_rpi
 
-sys.modules['RPi'] = fake_rpi.RPi     # Fake RPi (GPIO)
+sys.modules['RPi'] = fake_rpi.RPi     # Fake RPi
+sys.modules['RPi.GPIO'] = fake_rpi.RPi.GPIO # Fake GPIO
 sys.modules['smbus'] = fake_rpi.smbus # Fake smbus (I2C)
 ```
 


### PR DESCRIPTION
 Fixed readme since it is necessary to modify 'RPi.GPIO' module to import RPi.GPIO as GPIO